### PR TITLE
fix fees

### DIFF
--- a/includes/class-wc-pagseguro-api.php
+++ b/includes/class-wc-pagseguro-api.php
@@ -418,11 +418,13 @@ class WC_PagSeguro_API {
 			// Fees.
 			if ( 0 < sizeof( $order->get_fees() ) ) {
 				foreach ( $order->get_fees() as $fee ) {
-					$items[] = array(
-						'description' => $this->sanitize_description( $fee['name'] ),
-						'amount'      => $this->money_format( $fee['line_total'] ),
-						'quantity'    => 1
-					);
+					if ( 0 < $fee['line_total'] ) {
+						$items[] = array(
+							'description' => $this->sanitize_description( $fee['name'] ),
+							'amount'      => $this->money_format( $fee['line_total'] ),
+							'quantity'    => 1
+						);
+					}
 				}
 			}
 


### PR DESCRIPTION
Ao utilizar o plugin Checkout Add-Ons, se um dos campos criados for uma opção sem custo nenhum, mesmo assim ele cria a taxa de 0.00. Com isso não é possível finalizar o pagamento no checkout transparente do PagSeguro.

Agora, adicionei uma verificação para adicionar a taxa ao PagSeguro apenas se for maior que zero. Isso resolve o problema.